### PR TITLE
Refactor: Remove retry attempts from res to ctx.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -332,7 +332,7 @@ function toRetry(err) {
 }
 
 function retry(fn, ctx) {
-  ctx.res.retries = [];
+  ctx.retryAttempts = [];
   const maxAttempts = ctx.retries;
 
   function attempt(i) {
@@ -346,7 +346,7 @@ function retry(fn, ctx) {
       })
       .catch((err) => {
         if (i < maxAttempts && isCriticalError(err)) {
-          ctx.res.retries.push(toRetry(err));
+          ctx.retryAttempts.push(toRetry(err));
           return attempt(++i);
         }
         throw err;

--- a/lib/context.js
+++ b/lib/context.js
@@ -13,10 +13,23 @@ const USER_AGENT = `${packageInfo.name}/${packageInfo.version}`;
 class Context {
   constructor(defaults) {
     this.retries = 0;
+    this._retryAttempts = [];
     this.plugins = [];
     this.req = Request.create();
     this.res = Response.create();
     if (defaults) this._applyDefaults(defaults);
+  }
+
+  get retryAttempts() {
+    if (_.isUndefined(this._retryAttempts)) return [];
+    return this._retryAttempts;
+  }
+
+  set retryAttempts(retryAttempts) {
+    if (!Array.isArray(retryAttempts)) {
+      retryAttempts = [];
+    }
+    this._retryAttempts = retryAttempts;
   }
 
   addPlugin(plugin) {

--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -3,7 +3,8 @@
 const _ = require('lodash');
 
 function isRetry(ctx) {
-  return _.get(ctx, 'res.retries', []).length > 0;
+  const attempts = ctx.retryAttempts || [];
+  return attempts.length > 0;
 }
 
 function isCriticalError(ctx) {
@@ -29,7 +30,7 @@ function createRequestMessage(ctx) {
 
 function createRetryMessage(ctx) {
   const res = ctx.res;
-  const attempts = res.retries;
+  const attempts = ctx.retryAttempts;
 
   const message = `Attempt ${attempts.length} ${getBaseMessage(ctx)}`;
   if (hasElapsedTime(ctx)) return `${message} ${res.elapsedTime} ms`;

--- a/lib/response.js
+++ b/lib/response.js
@@ -17,7 +17,6 @@ class Response {
     this.url;
     this.statusCode;
     this.body;
-    this._retries;
   }
 
   getHeader(header) {
@@ -43,18 +42,6 @@ class Response {
       return this.body.length;
     }
     return JSON.stringify(this.body).length;
-  }
-
-  get retries() {
-    if (_.isUndefined(this._retries)) return [];
-    return this._retries;
-  }
-
-  set retries(retries) {
-    if (!Array.isArray(retries)) {
-      retries = [];
-    }
-    this._retries = retries;
   }
 
   toJSON() {

--- a/test/client.js
+++ b/test/client.js
@@ -245,23 +245,6 @@ describe('HttpTransportClient', () => {
       assert.equal(res.statusCode, 200);
     });
 
-    it('tracks retry attempts', async () => {
-      nockRetries(2);
-
-      const client = HttpTransport.createClient();
-
-      const res = await client
-        .get(url)
-        .use(toError())
-        .retry(2)
-        .asResponse();
-
-      const retries = res.retries;
-      assert.equal(retries.length, 2);
-      assert.equal(retries[0].statusCode, 500);
-      assert.match(retries[0].reason, /something bad/);
-    });
-
     it('does not retry 4XX errors', async () => {
       nock.cleanAll();
       api

--- a/test/context.js
+++ b/test/context.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const assert = require('assert');
+const Context = require('../lib/context');
+
+describe('Context', () => {
+  it('defaults retries to an empty array', () => {
+    const response = Context.create();
+    assert.deepEqual(response.retryAttempts, []);
+  });
+
+  it('returns an array of retries', () => {
+    const attempts = [{ a: 1 }, { b: 2 }];
+    const context = Context.create();
+    context.retryAttempts = attempts;
+    assert.deepEqual(context.retryAttempts, attempts);
+  });
+
+  it('always sets retry attempts to an empty array', () => {
+    const attempts = [];
+    const context = Context.create();
+    context.retryAttempts = 'crazy input';
+    assert.deepEqual(context.retryAttempts, attempts);
+  });
+});

--- a/test/response.js
+++ b/test/response.js
@@ -100,23 +100,4 @@ describe('Response', () => {
     const asJson = JSON.parse(asString);
     assert.deepEqual(asJson, state);
   });
-
-  it('defaults retries to an empty array', () => {
-    const response = Response.create();
-    assert.deepEqual(response.retries, []);
-  });
-
-  it('returns an array of retries', () => {
-    const retries = [{ a: 1 }, { b: 2 }];
-    const response = Response.create();
-    response.retries = retries;
-    assert.deepEqual(response.retries, retries);
-  });
-
-  it('always sets retries to an empty array', () => {
-    const retries = [];
-    const response = Response.create();
-    response.retries = 'crazy input';
-    assert.deepEqual(response.retries, retries);
-  });
 });


### PR DESCRIPTION
**Change summary:**
1. Moves tracking retries from the Response to the Context 
2. Therefore, retry attempts info will no longer be expose to the caller. This behaviour is not currently used. 
3. Retry attempts info will be available to the middleware via the context. This is useful for some middleware (stats, logger). 

**Side effects:**

1. Breaks current stats middleware. New version required to use context for retries. 
2. Logging middleware has been fixed as part of this PR as it's default middleware. 
3. Core client will need to be a major release 

**Follow up changes:**
Potential to review other context/request/response properties that can be modified. What are the side effects? Can middleware have the potential to break a request? etc etc 