### PR TITLE
Fixed typescript compiler which lacks return-type annotation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -116,7 +116,7 @@ declare class Context {
   req: Request
   res: Response
 
-  static create(defaults: contextDefaults)
+  static create(defaults: contextDefaults): any
   retryAttempts: Array<RetryAttempt>
   addPlugin(plugin: Plugin): Context
 }


### PR DESCRIPTION
Add return type to fixed issue with typescript compiler _error TS7010: 'create', which lacks return-type annotation, implicitly has an 'any' return type._
#26 