### PR TITLE
Stop DNS.lookup from preferring IPv4 addresses

### DIFF
--- a/lib/transport/request.js
+++ b/lib/transport/request.js
@@ -33,7 +33,7 @@ class RequestTransport extends Transport {
     const req = ctx.req;
 
     const opts = Object.assign({
-      time: true,
+      time: true
     }, ctx.opts);
 
     if (req.getTimeout() !== undefined) {

--- a/lib/transport/request.js
+++ b/lib/transport/request.js
@@ -24,7 +24,7 @@ class RequestTransport extends Transport {
     this._request = promisifyAll(customRequest || Request);
   }
 
-  customDNSLookup(domain, opts={}, callback) {
+  customDNSLookup(domain, opts = {}, callback) {
     opts.verbatim = true; // Do not prefer IPv4 over IPv6. Node is a great language.
     return DNS.lookup(domain, opts, callback);
   }

--- a/lib/transport/request.js
+++ b/lib/transport/request.js
@@ -25,7 +25,7 @@ class RequestTransport extends Transport {
   }
 
   customDNSLookup(domain, opts = {}, callback) {
-    opts.verbatim = true; // Do not prefer IPv4 over IPv6. Node is a great language.
+    opts.verbatim = true; // Do not prefer IPv4 over IPv6
     return DNS.lookup(domain, opts, callback);
   }
 

--- a/lib/transport/request.js
+++ b/lib/transport/request.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const promisifyAll = require('./promiseUtils').promisifyAll;
 const Transport = require('./transport');
 const Request = require('request');
+const DNS = require('dns');
 
 const REQUIRED_PROPERTIES = [
   'body',
@@ -23,15 +24,24 @@ class RequestTransport extends Transport {
     this._request = promisifyAll(customRequest || Request);
   }
 
+  customDNSLookup(domain, opts={}, callback) {
+    opts.verbatim = true; // Do not prefer IPv4 over IPv6. Node is a great language.
+    return DNS.lookup(domain, opts, callback);
+  }
+
   toOptions(ctx) {
     const req = ctx.req;
 
     const opts = Object.assign({
-      time: true
+      time: true,
     }, ctx.opts);
 
     if (req.getTimeout() !== undefined) {
       opts.timeout = req.getTimeout();
+    }
+
+    if (_.isUndefined(opts.lookup)) {
+      opts.lookup = this.customDNSLookup
     }
 
     if (!_.isUndefined(req.time)) opts.time = req.time;

--- a/test/transport/request.js
+++ b/test/transport/request.js
@@ -251,5 +251,18 @@ describe('Request HTTP transport', () => {
         })
         .catch(assert.ifError);
     });
+    it('uses customDNSLookup function by default', () => {
+      nock.cleanAll();
+      api.get('/').reply(200, simpleResponseBody);
+
+      const ctx = createContext(url);
+
+      return new RequestTransport()
+        .execute(ctx)
+        .then((ctx) => {
+          assert.equal(ctx.res.httpResponse.request.lookup.name, 'customDNSLookup');
+        })
+        .catch(assert.ifError);
+    });
   });
 });


### PR DESCRIPTION
Set `verbatim` flag to `true` in calls to `DNS.lookup`, this stops Node from re-ordering responses from DNS servers to prefer IPv4. This is recommended for new code. See https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback

Rationale for making this change is when using Flashheart on AWS with IPv6 configured endpoints, requests are being routed to IPv4 endpoints via the NAT Gateway which incurs data processing costs.