### PR TITLE
Set verbatim flag for calls to dns.lookup

### DIFF
--- a/lib/transport/request.js
+++ b/lib/transport/request.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const promisifyAll = require('./promiseUtils').promisifyAll;
 const Transport = require('./transport');
 const Request = require('request');
+const dns = require('dns');
 
 const REQUIRED_PROPERTIES = [
   'body',
@@ -25,9 +26,16 @@ class RequestTransport extends Transport {
 
   toOptions(ctx) {
     const req = ctx.req;
-
     const opts = Object.assign({
-      time: true
+      time: true,
+      agentOptions: {
+        lookup: function(domain, options, cb) {
+          // Prevent Node from reordering A and AAAA records.
+          // See https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback
+          options.verbatim = true;
+          return dns.lookup(domain, options, cb);
+        }
+      }
     }, ctx.opts);
 
     if (req.getTimeout() !== undefined) {
@@ -58,7 +66,6 @@ class RequestTransport extends Transport {
   makeRequest(ctx, opts) {
     const url = ctx.req.getUrl();
     const method = ctx.req.getMethod();
-
     return this._request[toAsyncMethod(method)](url, opts);
   }
 }


### PR DESCRIPTION
To address issue #30, create a custom lookup function which wraps `dns.lookup` to set the `verbatim` flag to `true`. This stops Node from reordering DNS responses to prefer IPv4, and instead the order sent by the resolver is returned.