### PR TITLE
Type fix, and a type improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 package-lock.json
 .nyc_output
 .vscode
+.idea

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,7 +92,7 @@ export declare class Response {
   static create(opts?: JsonResponse): Response;
   addHeader(key: string, value: string): Request;
   getHeader(key: string): string;
-  toJson(): JsonResponse;
+  toJSON(): JsonResponse;
 }
 
 export declare class HttpTransportBuilder<

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ export declare type Plugin<
   ContextCurrent extends Context = Context
 > = (
   ctx: ContextCurrent & ContextExtra,
-  next: () => void | Promise<void>
+  next: () => (void | Promise<void>)
 ) => any;
 export declare type Header = Object;
 export declare type Querystring = Object;


### PR DESCRIPTION
## Description

1. Fix `Response.toJSON()` being wrongly typed as `Response.toJson()`.
2. Add some parentheses to the return type for the `next` parameter for Plugins, to make it more readable.
3. Add .idea to the .gitignore, for those of us who use Webstorm.

## Motivation and Context

1. Remove the need for hacky workarounds when using TypeScript.
2. Avoid confusion over types (see #39).
3. QOL improvement for developers who use WebStorm.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (N/A)
- [x] All new and existing tests passed.
