### PR TITLE
IPLAYER-43506: Update `Body` type within `Response` to return all possible types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ export declare type Plugin<
 ) => any;
 export declare type Header = Object;
 export declare type Querystring = Object;
-export declare type Body = string | object | null;
+export declare type Body = string | Object | null;
 export declare type RequestOptions = Object;
 export declare type ErrorObject = {
   message: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ export declare type Plugin<
 ) => any;
 export declare type Header = Object;
 export declare type Querystring = Object;
-export declare type Body = string;
+export declare type Body = string | object | null;
 export declare type RequestOptions = Object;
 export declare type ErrorObject = {
   message: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
 Updates `Body` type within `Response` to return all possible types (`string`, `Object`, `null`)
## Motivation and Context
iPlayer Web are currently working on migrating our client libraries to use the latest http-transport package. We have question around on the typings in http-transport, specifically the Body type within the Response object: https://github.com/bbc/http-transport/blob/main/index.d.ts#L19

Currently, `Body` is set to be a type of `string`, however our clients are expecting `Body` to be an `Object` as the responses we get back are in JSON format. Looking at the asResponse [function here in http-transport](https://github.com/bbc/http-transport/blob/main/lib/transport/node-fetch.js#L78-L86), it looks like the `Body` can be a `string`, an `Object` or possibly even `null`

Would it be more accurate to set `Body` to have a type of `string | Object | null`?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
