### PR TITLE
fix: client no longer delays when it wont retry

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -360,7 +360,7 @@ function retry(fn, ctx) {
   function attempt(i) {
     return fn(ctx)
       .catch((err) => {
-        if (maxAttempts > 0) {
+        if (i < maxAttempts && isCriticalError(err) && ctx.retryDelay && ctx.retryDelay > 0) {
           const delayBy = rejectedPromise(ctx.retryDelay);
           return delayBy(err);
         }


### PR DESCRIPTION
## Description
In the retry function, delay was firing without hitting retry, resulting in increased response times. We modified the function to only delay when the retry occurs. 
## Motivation and Context
[Jira ticket](https://jira.dev.bbc.co.uk/browse/IPLAYER-45275)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
