### PR TITLE
Iplayer 45725 circuit breaker mware

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,7 @@ export declare class HttpTransportBuilder<
   userAgent(userAgent: string): HttpTransportBuilder<ContextCurrent>;
   retries(retries: number): HttpTransportBuilder<ContextCurrent>;
   retryDelay(retryDelay: number): HttpTransportBuilder<ContextCurrent>;
+  criticalErrorDetector(criticalErrorDetector: (err, ctx: Context) => boolean);
   use<ContextExtra = {}>(
     fn: Plugin<ContextExtra, ContextCurrent>
   ): HttpTransportBuilder<ContextExtra & ContextCurrent>;
@@ -141,7 +142,7 @@ export declare class HttpTransportClient<
     ResponseBody
   >;
   asResponse<ResponseBody = ContextCurrent["res"]["body"]>(): Promise<
-    AsResponse<ContextCurrent["res"], ResponseBody>  
+    AsResponse<ContextCurrent["res"], ResponseBody>
   >;
 }
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -70,6 +70,36 @@ class HttpTransportBuilder {
   }
 
   /**
+   * default the criticalErrorDetector which parses errors and decides if they are critical. This mainly enables retry logic.
+   * @param {function} criticalErrorDetector (err, ctx) => bool - a function that takes the error and the context and returns a boolean which evaluates whether an error is a critical error.
+   * This is useful if you want to customise error behaviour. See below for example that prevents circuitBreaker errors from being classed as critical errors.
+   * criticalErrors trigger retry behaviour and so may not be desirable in all scenarios.
+   * @return a HttpTransportBuilder instance
+   * @example
+   * const httpTransport = require('@bbc/http-transport');
+   *
+   * const builder = httpTransport.createBuilder();
+   * builder.criticalErrorDetector(() => {
+   *  if (err && (err.statusCode < 500 || err.isBrokenCircuitError)) {
+   *    return false;
+   *  }
+   *  return true;
+   * });
+   *
+   * @default
+   * (err, ctx) => {
+   *   if (err && err.statusCode < 500) {
+   *     return false;
+   *   }
+   *   return true;
+   * }
+   */
+  criticalErrorDetector(criticalErrorDetector) {
+    _.set(this._defaults, 'ctx.criticalErrorDetector', criticalErrorDetector);
+    return this;
+  }
+
+  /**
    * Registers a global plugin, which is used for all requests
    *
    * @param {function} fn - a global plugin

--- a/lib/client.js
+++ b/lib/client.js
@@ -340,7 +340,7 @@ class HttpTransportClient {
 }
 
 function isCriticalError(err) {
-  if (err && err.statusCode < 500) {
+  if (err && (err.statusCode < 500 || err.isBrokenCircuitError)) {
     return false;
   }
   return true;

--- a/lib/client.js
+++ b/lib/client.js
@@ -339,8 +339,10 @@ class HttpTransportClient {
   }
 }
 
-function isCriticalError(err) {
-  if (err && (err.statusCode < 500 || err.isBrokenCircuitError)) {
+function isCriticalError(err, ctx) {
+  if (ctx.criticalErrorDetector) return ctx.criticalErrorDetector(err, ctx);
+
+  if (err && err.statusCode < 500) {
     return false;
   }
   return true;
@@ -363,14 +365,14 @@ function retry(fn, ctx) {
   function attempt(i) {
     return fn(ctx)
       .catch((err) => {
-        if (i < maxAttempts && isCriticalError(err) && ctx.retryDelay && ctx.retryDelay > 0) {
+        if (i < maxAttempts && isCriticalError(err, ctx) && ctx.retryDelay && ctx.retryDelay > 0) {
           const delayBy = rejectedPromise(ctx.retryDelay);
           return delayBy(err);
         }
         throw err;
       })
       .catch((err) => {
-        if (i < maxAttempts && isCriticalError(err)) {
+        if (i < maxAttempts && isCriticalError(err, ctx)) {
           ctx.retryAttempts.push(toRetry(err));
           return attempt(++i);
         }

--- a/lib/context.js
+++ b/lib/context.js
@@ -19,6 +19,7 @@ class Context {
     this.plugins = [];
     this.req = Request.create();
     this.res = Response.create();
+    this.criticalErrorDetector = undefined;
     if (defaults) this._applyDefaults(defaults);
   }
 
@@ -42,6 +43,7 @@ class Context {
     this.userAgent = defaults.ctx?.userAgent || USER_AGENT;
     this.retries = defaults.ctx?.retries || RETRIES;
     this.retryDelay = defaults.ctx?.retryDelay || RETRY_DELAY;
+    this.criticalErrorDetector = defaults.ctx?.criticalErrorDetector;
   }
 
   static create(defaults) {

--- a/test/client.js
+++ b/test/client.js
@@ -141,6 +141,22 @@ describe('HttpTransportClient', () => {
       assert.equal(ctx.retries, 50);
       assert.equal(ctx.retryDelay, 2000);
     });
+
+    it('sets default criticalErrorDetector in the context', async () => {
+      const transport = new Transport();
+      sandbox.stub(transport, 'execute').returns(Promise.resolve());
+
+      const client = HttpTransport.createBuilder(transport)
+        .criticalErrorDetector(() => false)
+        .createClient();
+
+      await client
+        .get(url)
+        .asResponse();
+
+      const ctx = transport.execute.getCall(0).args[0];
+      assert.equal(ctx.criticalErrorDetector.toString(), (() => false).toString());
+    });
   });
 
   describe('.retries', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding in the ability to configure a "criticalErrorDetector" to HttpTransportBuilder to allow for customisable retry logic.
<!--- Why is this change required? What problem does it solve? -->
Allows the prevention of retries when errors occur that should not be retried.
[IPLAYER-45726
](https://jira.dev.bbc.co.uk/browse/IPLAYER-45726)
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
